### PR TITLE
Make sure Hugging Face download stats work, better discoverability

### DIFF
--- a/ultralytics/engine/model.py
+++ b/ultralytics/engine/model.py
@@ -10,8 +10,10 @@ from ultralytics.nn.tasks import attempt_load_one_weight, guess_model_task, nn, 
 from ultralytics.utils import ASSETS, DEFAULT_CFG_DICT, LOGGER, RANK, SETTINGS, callbacks, checks, emojis, yaml_load
 from ultralytics.hub.utils import HUB_WEB_ROOT
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class Model(nn.Module):
+
+class Model(nn.Module, PyTorchModelHubMixin):
     """
     A base class to unify APIs for all models.
 


### PR DESCRIPTION
Hi @LilianHollard,

Thanks for this nice work! I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various LeYOLO models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Usage is as follows:

```
from ultralytics import YOLO

model = YOLO.from_pretrained("your-hf-username/leyolo-nano")

# optionally, one can push a trained model to the hub
model.push_to_hub("nielsr/my-awesome-leyolo-model")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. We could move all checkpoints to separate repos to an organization on the hub or your personal user account if you're interested.

cc also @kadirnar who did a great job already at making the models available on 🤗. Would be great to leverage the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) from now on for new models as it makes downloads etc work :)

Would you be interested in this integration?

Kind regards,

Niels